### PR TITLE
allow Java 11 syntax

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,8 +33,6 @@ tasks.register<Test>("testToolsNotInstalled") {
 }
 
 java {
-    toolchain {
-        sourceCompatibility = org.gradle.api.JavaVersion.VERSION_1_8
-        targetCompatibility = org.gradle.api.JavaVersion.VERSION_1_8
-    }
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }


### PR DESCRIPTION
As Java 11 is our target platform, we should not restric the code to Java 8