### PR TITLE
add jacoco test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,14 @@ commands:
   store_test_results_and_artifacts:
     steps:
       - store_test_results:
-          path: build/test-results
+          path: "build/test-results"
       - store_artifacts:
-          path: build/test-results
+          path: "build/test-results"
       - store_artifacts:
-          path: build/reports
+          path: "build/reports"
+      - persist_to_workspace:
+          root: "build/jacoco"
+          paths: "*.exec"
 
 jobs:
   run_tests_java:
@@ -102,6 +105,17 @@ jobs:
           ./gradlew clean :integrationTestToolsNotInstalled -i
       - store_test_results_and_artifacts
 
+  merged_coverage_report:
+    docker:
+      - image: *test_docker_image
+    steps:
+      - checkout
+      - attach_workspace:
+          at: "build/jacoco"
+      - run: |
+          ./gradlew :jacocoTestReport -i
+      - store_test_results_and_artifacts
+
 workflows:
   version: 2
   run_tests:
@@ -112,3 +126,10 @@ workflows:
       - run_tests_tex_packages_not_installed_java
       - run_integration_tests_java
       - run_integration_tests_tools_not_installed_java
+      - merged_coverage_report:
+          requires:
+            - run_tests_java
+            - run_tests_tools_not_installed_java
+            - run_tests_tex_packages_not_installed_java
+            - run_integration_tests_java
+            - run_integration_tests_tools_not_installed_java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,16 @@ commands:
           # contains the pango font. Without it, there is this error: 
           # "java.util.concurrent.ExecutionException: java.lang.UnsatisfiedLinkError: no javafx_font_pango in java.library.path"
           sudo apt-get install libpangoft2-1.0-0
+
+  store_test_results_and_artifacts:
+    steps:
+      - store_test_results:
+          path: build/test-results
+      - store_artifacts:
+          path: build/test-results
+      - store_artifacts:
+          path: build/reports
+
 jobs:
   run_tests_java:
     docker:
@@ -44,10 +54,7 @@ jobs:
       - install_pdf_tools
       - run: |
           ./gradlew :test -i
-      - store_test_results:
-          path: build/test-results
-      - store_artifacts:
-          path: build/test-results
+      - store_test_results_and_artifacts
 
   run_tests_tools_not_installed_java:
     docker:
@@ -56,10 +63,7 @@ jobs:
       - checkout
       - run: |
           ./gradlew clean :testToolsNotInstalled -i
-      - store_test_results:
-          path: build/test-results
-      - store_artifacts:
-          path: build/test-results
+      - store_test_results_and_artifacts
 
   run_tests_tex_packages_not_installed_java:
     docker:
@@ -69,10 +73,7 @@ jobs:
       - install_pdf_tools_without_packages
       - run: |
           ./gradlew clean :testTexPackagesNotInstalled -i
-      - store_test_results:
-          path: build/test-results
-      - store_artifacts:
-          path: build/test-results
+      - store_test_results_and_artifacts
 
   run_integration_tests_java:
     docker:
@@ -86,10 +87,7 @@ jobs:
           # So this is a workaround.
           export JAVA_TOOL_OPTIONS="-DCI=true"
           ./gradlew :integrationTest -i
-      - store_test_results:
-          path: build/test-results
-      - store_artifacts:
-          path: build/test-results
+      - store_test_results_and_artifacts
 
   run_integration_tests_tools_not_installed_java:
     docker:
@@ -102,10 +100,7 @@ jobs:
           # So this is a workaround.
           export JAVA_TOOL_OPTIONS="-DCI=true"
           ./gradlew clean :integrationTestToolsNotInstalled -i
-      - store_test_results:
-          path: build/test-results
-      - store_artifacts:
-          path: build/test-results
+      - store_test_results_and_artifacts
 
 workflows:
   version: 2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,8 +132,6 @@ dependencies {
 
 // ######################################### Java application #########################################
 
-val javaFxVersion = "19-ea+3"
-
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
@@ -166,12 +164,12 @@ tasks.jacocoTestReport {
 
 // ######################################### JavaFX #########################################
 
+val javaFxVersion = "19-ea+3"
+
 javafx {
     version = javaFxVersion
     modules("javafx.controls", "javafx.fxml")
 }
-
-
 
 jlink {
     imageZip.set(project.file("${buildDir}/distributions/app-${javafx.platform.classifier}.zip"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("application")
     id("org.openjfx.javafxplugin") version "0.0.12"
     id("org.beryx.jlink") version "2.24.4"
+    id("jacoco")
 }
 
 group = "org.example"
@@ -13,6 +14,10 @@ repositories {
 }
 
 val javaFxVersion = "19-ea+3"
+
+jacoco {
+    toolVersion = "0.8.7"
+}
 
 
 // separate integration testing module - cf https://docs.gradle.org/current/samples/sample_java_modules_multi_project.html
@@ -109,18 +114,21 @@ tasks.getByName<Test>("test") {
         excludeTags("toolsNotInstalled")
         excludeTags("texPackagesNotInstalled")
     }
+    finalizedBy(tasks.jacocoTestReport)
 }
 // runs only "toolsNotInstalled" tests
 tasks.register<Test>("testToolsNotInstalled") {
     useJUnitPlatform {
         includeTags("toolsNotInstalled")
     }
+    finalizedBy(tasks.jacocoTestReport)
 }
 // runs only "texPackagesNotInstalled" tests
 tasks.register<Test>("testTexPackagesNotInstalled") {
     useJUnitPlatform {
         includeTags("texPackagesNotInstalled")
     }
+    finalizedBy(tasks.jacocoTestReport)
 }
 
 // don't run the "not installed" tests by default

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,11 +157,10 @@ tasks.withType(Test::class.java) {
 }
 tasks.jacocoTestReport {
     val fileNameFilter: (File, String) -> Boolean = { _: File, name: String -> name.endsWith(".exec") }
-    val lazyFromFilesProvider: () -> Array<File>? = {
+    val lazyFromFilesProvider: Provider<Array<File>> =
         layout.buildDirectory.dir("jacoco")
                 .map { it.asFile.listFiles(fileNameFilter) }
-                .orNull
-    }
+                .orElse(emptyArray())
     executionData.from(lazyFromFilesProvider)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -156,13 +156,13 @@ tasks.withType(Test::class.java) {
     finalizedBy(tasks.jacocoTestReport)
 }
 tasks.jacocoTestReport {
-    executionData.from(
-            layout.buildDirectory.file("jacoco/test.exec"),
-            layout.buildDirectory.file("jacoco/testToolsNotInstalled.exec"),
-            layout.buildDirectory.file("jacoco/testTexPackagesNotInstalled.exec"),
-            layout.buildDirectory.file("jacoco/integrationTest.exec"),
-            layout.buildDirectory.file("jacoco/integrationTestToolsNotInstalled.exec")
-    )
+    val fileNameFilter: (File, String) -> Boolean = { _: File, name: String -> name.endsWith(".exec") }
+    val lazyFromFilesProvider: () -> Array<File>? = {
+        layout.buildDirectory.dir("jacoco")
+                .map { it.asFile.listFiles(fileNameFilter) }
+                .orNull
+    }
+    executionData.from(lazyFromFilesProvider)
 }
 
 // ######################################### JavaFX #########################################

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,7 +109,7 @@ dependencies {
 }
 
 // runs all tests except "toolsNotInstalled" and "texPackagesNotInstalled"
-tasks.getByName<Test>("test") {
+tasks.test {
     useJUnitPlatform {
         excludeTags("toolsNotInstalled")
         excludeTags("texPackagesNotInstalled")
@@ -121,6 +121,9 @@ tasks.register<Test>("testToolsNotInstalled") {
     useJUnitPlatform {
         includeTags("toolsNotInstalled")
     }
+    extensions.configure(JacocoTaskExtension::class) {
+        setDestinationFile(layout.buildDirectory.file("jacoco/test.exec").get().asFile)
+    }
     finalizedBy(tasks.jacocoTestReport)
 }
 // runs only "texPackagesNotInstalled" tests
@@ -128,7 +131,14 @@ tasks.register<Test>("testTexPackagesNotInstalled") {
     useJUnitPlatform {
         includeTags("texPackagesNotInstalled")
     }
+    extensions.configure(JacocoTaskExtension::class) {
+        setDestinationFile(layout.buildDirectory.file("jacoco/test.exec").get().asFile)
+    }
     finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    executionData.from(layout.buildDirectory.file("jacoco/test.exec"))
 }
 
 // don't run the "not installed" tests by default

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,6 @@ val integrationTestJarTask = tasks.register<Jar>(integrationTest.jarTaskName) {
 
 val commonIntegrationTestConfiguration: Test.() -> Unit = {
     description = "Runs integration tests."
-    group = "verification"
     jvmArgs = listOf("--add-exports", "javafx.graphics/com.sun.javafx.application=org.testfx",
             "--add-exports", "javafx.graphics/com.sun.glass.ui=ALL-UNNAMED",
             "--add-opens", "javafx.graphics/com.sun.glass.ui=org.testfx",
@@ -153,13 +152,17 @@ jacoco {
 }
 
 tasks.withType(Test::class.java) {
-    extensions.configure(JacocoTaskExtension::class) {
-        setDestinationFile(layout.buildDirectory.file("jacoco/test.exec").get().asFile)
-    }
+    group = "verification"
     finalizedBy(tasks.jacocoTestReport)
 }
 tasks.jacocoTestReport {
-    executionData.from(layout.buildDirectory.file("jacoco/test.exec"))
+    executionData.from(
+            layout.buildDirectory.file("jacoco/test.exec"),
+            layout.buildDirectory.file("jacoco/testToolsNotInstalled.exec"),
+            layout.buildDirectory.file("jacoco/testTexPackagesNotInstalled.exec"),
+            layout.buildDirectory.file("jacoco/integrationTest.exec"),
+            layout.buildDirectory.file("jacoco/integrationTestToolsNotInstalled.exec")
+    )
 }
 
 // ######################################### JavaFX #########################################

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,23 +114,21 @@ tasks.test {
         excludeTags("toolsNotInstalled")
         excludeTags("texPackagesNotInstalled")
     }
-    finalizedBy(tasks.jacocoTestReport)
 }
 // runs only "toolsNotInstalled" tests
 tasks.register<Test>("testToolsNotInstalled") {
     useJUnitPlatform {
         includeTags("toolsNotInstalled")
     }
-    extensions.configure(JacocoTaskExtension::class) {
-        setDestinationFile(layout.buildDirectory.file("jacoco/test.exec").get().asFile)
-    }
-    finalizedBy(tasks.jacocoTestReport)
 }
 // runs only "texPackagesNotInstalled" tests
 tasks.register<Test>("testTexPackagesNotInstalled") {
     useJUnitPlatform {
         includeTags("texPackagesNotInstalled")
     }
+}
+
+tasks.withType(Test::class.java) {
     extensions.configure(JacocoTaskExtension::class) {
         setDestinationFile(layout.buildDirectory.file("jacoco/test.exec").get().asFile)
     }


### PR DESCRIPTION
Part of https://github.com/SergelsOrg/csv2tex/issues/77

----

* Following the instructions here: https://docs.gradle.org/current/userguide/jacoco_plugin.html
* Minor adjustments were necessary (specify a fixed file name) to get coverage for all types of tests
* Merging the output files of the different test runs may be too complex and thus out of scope for now 
  * We could have the single test runs create coverage-data files as part of a pipeline, store them in a workspace under different names, then later merge them 
    * e.g. merge using https://docs.gradle.org/current/dsl/org.gradle.testing.jacoco.tasks.JacocoMerge.html 
      * it's deprecated though because "The [JacocoReport](https://docs.gradle.org/current/javadoc/org/gradle/testing/jacoco/tasks/JacocoReport.html) task accepts multiple execution files as an input."