### PR TITLE
Don't catch throwable

### DIFF
--- a/src/main/java/org/example/csv2tex/rendering/SchoolReportsRenderer.java
+++ b/src/main/java/org/example/csv2tex/rendering/SchoolReportsRenderer.java
@@ -58,8 +58,8 @@ public class SchoolReportsRenderer {
             return renderSchoolReportsForGivenFiles(studentDataList, texTemplate, temporaryDirectory, shellCommandsInTempDir);
         } catch (RenderingException | InvalidCsvException e) {
             throw e;
-        } catch (Throwable t) {
-            throw new RenderingException(t);
+        } catch (Exception e) {
+            throw new RenderingException(e);
         }
     }
 


### PR DESCRIPTION
Don't catch Throwable:s - these may be
Exceptions or Errors, and catching Errors
(like OutOfMemoryError) may bring unwanted
side effects, making your application unstable.

E.g. see [this rule](https://pmd.github.io/latest/pmd_rules_java_errorprone.html#avoidcatchingthrowable) in the PMD static code analyzer.