### PR TITLE
Flaky tests: Increase shell timeout to allow for longer-running renderings

### DIFF
--- a/src/main/java/org/example/csv2tex/shellout/ShellCommandsUtil.java
+++ b/src/main/java/org/example/csv2tex/shellout/ShellCommandsUtil.java
@@ -107,7 +107,7 @@ public class ShellCommandsUtil {
         }
 
         try {
-            boolean terminatedCorrectly = process.waitFor(1, TimeUnit.SECONDS);
+            boolean terminatedCorrectly = process.waitFor(30, TimeUnit.SECONDS);
             return new ShellResult(getContentFromStream(process.getInputStream()),
                     getContentFromStream(process.getErrorStream()),
                     getExitValue(process), terminatedCorrectly);


### PR DESCRIPTION
I noticed a sometimes-failing (flaky) test on the main branch.

```
org.example.csv2tex.ErfurtSchoolReportSmokeTest
RenderingException{cause=SHELL_COMMAND_FAILED, additionalMessage='
ShellResult{
stdout=Optional[
This is pdfTeX, Version 3.14159265-2.6-1.40.20 (TeX Live 2019/Debian) (preloaded format=pdflatex) 
restricted \write18 enabled.
entering extended mode
LaTeX2e 
<2020-02-02> patch level 2L3 programming layer 
<2020-02-14>(/tmp/SchoolReportsRenderer17539504050464511336/schoolReport_0.tex(/tmp/SchoolReportsRenderer17539504050464511336/SchoolReportTemplate_ZeugnisTemplate_Packages.tex
[...]
Output written on schoolReport_0.pdf (3 pages, 87603 bytes).Transcript written on schoolReport_0.log.
], stderr=Optional[], exitCode=Optional.empty, successfulExit=false}'}
```

https://app.circleci.com/pipelines/github/SergelsOrg/csv2tex/285/workflows/918bc317-886e-4c7f-a0f5-d8e9976ef2f4/jobs/1153

What strikes the eye here is that there is no non-0 exit code - the command did not finish successfully. 

Looking at the code, I found that we still hard-code a 1-second timeout to avoid hanging applications - this may be too low for real-life renderings of multiple pages.